### PR TITLE
Add support for multiple cursors

### DIFF
--- a/compile.hxml
+++ b/compile.hxml
@@ -13,13 +13,10 @@
 -D analyzer-optimize 
 
 # Haxe Source Map
---debug
+# --debug
 # --no-inline
 # --no-opt
 # -D keep_inline_positions
-
-# RM Version for Conditional Compilation
-# -D compileMV
 
 --macro macros.MacroTools.includeJsLib("./src/Parameters.js")
 # Note you can call an hxml file inside an hxml file for build purposes.
@@ -28,8 +25,9 @@
 --each
 
 --next
--js games/mz/js/plugins/Luna_MouseSystem.js
-
---next
 -D compileMV
 -js games/mv/js/plugins/Luna_MouseSystem.js
+
+--next
+-D !compileMV
+-js games/mz/js/plugins/Luna_MouseSystem.js

--- a/haxe_libraries/LunaTea.hxml
+++ b/haxe_libraries/LunaTea.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download "gh://github.com/LunaTechsDev/LunaTea#4d03bcc2e5f4c3350505a3762a4f2c29e4f7a6da" into LunaTea/0.9.5/github/4d03bcc2e5f4c3350505a3762a4f2c29e4f7a6da
+# @install: lix --silent download "gh://github.com/LunaTechsDev/LunaTea#7ec2971061ccc48fe7fe17993eef236ce3e2066d" into LunaTea/0.9.5/github/7ec2971061ccc48fe7fe17993eef236ce3e2066d
 -lib hxnodejs
 -lib jsfps
 -lib pixijs
--cp ${HAXE_LIBCACHE}/LunaTea/0.9.5/github/4d03bcc2e5f4c3350505a3762a4f2c29e4f7a6da/src/
+-cp ${HAXE_LIBCACHE}/LunaTea/0.9.5/github/7ec2971061ccc48fe7fe17993eef236ce3e2066d/src/
 -D LunaTea=0.9.5

--- a/haxe_libraries/LunaTea.hxml
+++ b/haxe_libraries/LunaTea.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download "gh://github.com/LunaTechsDev/LunaTea#7ec2971061ccc48fe7fe17993eef236ce3e2066d" into LunaTea/0.9.5/github/7ec2971061ccc48fe7fe17993eef236ce3e2066d
+# @install: lix --silent download "gh://github.com/LunatechsDev/LunaTea#98e0ab483223d958dc393febc974a630c7ff6481" into LunaTea/0.9.5/github/98e0ab483223d958dc393febc974a630c7ff6481
 -lib hxnodejs
 -lib jsfps
 -lib pixijs
--cp ${HAXE_LIBCACHE}/LunaTea/0.9.5/github/7ec2971061ccc48fe7fe17993eef236ce3e2066d/src/
+-cp ${HAXE_LIBCACHE}/LunaTea/0.9.5/github/98e0ab483223d958dc393febc974a630c7ff6481/src/
 -D LunaTea=0.9.5

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,11 +1,14 @@
+import macros.FnMacros;
 import core.CursorLoader;
 import sprites.CursorSprite;
 import core.Amaryllis;
 import rm.Globals;
 import scenes.LunaSceneBase;
+import core.Game_System;
 import core.LunaTouchInput;
 import core.LunaStage;
 import utils.Parse;
+import rm.objects.Game_System as RmGame_System;
 import rm.managers.PluginManager;
 import rm.types.RM.PluginSettings;
 
@@ -23,6 +26,8 @@ class Main {
     LunaStage.patch();
     LunaSceneBase.patch();
     registerPluginCommands();
+    utils.Comment.title('DataManager');
+    FnMacros.jsPatch(false, RmGame_System, Game_System);
   }
 
   public static function registerPluginCommands () {

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,14 +1,20 @@
+import rm.managers.ImageManager;
+import core.CursorLoader;
+import sprites.CursorSprite;
+import core.Amaryllis;
 import rm.Globals;
 import scenes.LunaSceneBase;
 import core.LunaTouchInput;
 import core.LunaStage;
 import utils.Parse;
+import rm.managers.PluginManager;
 import rm.types.RM.PluginSettings;
 
 using StringTools;
 using Lambda;
 
 class Main {
+  public static var pluginName: String = 'Luna_MouseSystem';
   public static var params: Dynamic;
 
   public static function main() {
@@ -17,5 +23,31 @@ class Main {
     LunaTouchInput.patch();
     LunaStage.patch();
     LunaSceneBase.patch();
+    registerPluginCommands();
   }
+
+  public static function registerPluginCommands () {
+    #if !compileMV
+    PluginManager.registerCommand(pluginName, 'showCursor', (args) -> {
+      var cursor: CursorSprite = untyped Amaryllis.currentScene()._cursor;
+      cursor.visible = true;
+      untyped document.body.style.cursor = 'none';
+    });
+    
+    PluginManager.registerCommand(pluginName, 'hideCursor', (args) -> {
+      var option: Dynamic = Parse.parseParameters(args);
+      var cursor: CursorSprite = untyped Amaryllis.currentScene()._cursor;
+      cursor.visible = false;
+      if (option.showDefault) {
+        untyped document.body.style.cursor = 'auto';
+      }
+    });
+
+    PluginManager.registerCommand(pluginName, 'changeCursor', (args: Dynamic) -> {
+      var bitmap = ImageManager.loadSystem(args.filename);
+      untyped Amaryllis.currentScene()._cursor.bitmap = bitmap;
+    });
+    #end
+  }
+
 }

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,4 +1,3 @@
-import rm.managers.ImageManager;
 import core.CursorLoader;
 import sprites.CursorSprite;
 import core.Amaryllis;
@@ -44,8 +43,7 @@ class Main {
     });
 
     PluginManager.registerCommand(pluginName, 'changeCursor', (args: Dynamic) -> {
-      var bitmap = ImageManager.loadSystem(args.filename);
-      untyped Amaryllis.currentScene()._cursor.bitmap = bitmap;
+      CursorLoader.changeCursor(args.filename);
     });
     #end
   }

--- a/src/Parameters.js
+++ b/src/Parameters.js
@@ -6,19 +6,22 @@
  * @author LunaTechs | inc0der
  * @url https://lunatechs.dev/plugins/luna-mouse-system/
  * 
- * @param cursorFilepath
- * @text Cursor Image
- * @desc The image to use as the default cursor
- * @type file
- * @dir img/system
- * @default GameCursor.png
+ * @param cursors
+ * @test Cursors
+ * @desc A list of default cursors
+ * @type struct<CursorData>[]
+ * @default []
  * 
  * @command changeCursor
  * @text Change Cursor
  * @desc Changes the current cursor
  * 
- * @arg cursorId
- * @desc The cursor ID you want to change to.
+ * @arg filename
+ * @text Cursor Filename
+ * @desc The filename of the cursor you want to change to.
+ * @type file
+ * @dir img/system
+ * @default GameCursor.png
  * 
  * @command hideCursor
  * @text Hide Cursor
@@ -62,4 +65,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
  * 
+ */
+
+/*~struct~CursorData:
+ * @param filename
+ * @text Cursor Image
+ * @desc The image to use as the default cursor
+ * @type file
+ * @dir img/system
+ * @default GameCursor.png 
  */

--- a/src/Parameters.js
+++ b/src/Parameters.js
@@ -13,6 +13,32 @@
  * @dir img/system
  * @default GameCursor.png
  * 
+ * @command changeCursor
+ * @text Change Cursor
+ * @desc Changes the current cursor
+ * 
+ * @arg cursorId
+ * @desc The cursor ID you want to change to.
+ * 
+ * @command hideCursor
+ * @text Hide Cursor
+ * @desc Hides the cursor from view.
+ * @type Bool
+ * @default true
+ * 
+ * @arg showDefault
+ * @desc Show the default MZ/MV mouse cursor after hiding your custom cursor?
+ * @type boolean
+ * @default true
+ * @on Show default cursor
+ * @off Hide default cursor
+ * 
+ * @command showCursor
+ * @text Show Cursor
+ * @desc Brings cursor back to view
+ * @type Bool
+ * @default true
+ * 
 @help
 
 A plugin that allows you to use custom mouse cursor images and to change them

--- a/src/Utils.hx
+++ b/src/Utils.hx
@@ -1,0 +1,11 @@
+using StringTools;
+
+class Utils {
+  public static function parseFilename(path: String, ?ext: Bool = true): String {
+    var filename = path.substr(path.lastIndexOf('/')).replace('/', '');
+    if (ext) {
+      return filename;
+    }
+    return filename.replace('.png', '');
+  }
+}

--- a/src/core/CursorLoader.hx
+++ b/src/core/CursorLoader.hx
@@ -1,28 +1,32 @@
 package core;
 
-import rm.core.Bitmap;
+import haxe.ds.Map;
 import sprites.CursorSprite;
-import rm.managers.ImageManager;
+import types.CursorData;
 
 class CursorLoader {
-  private var _cache: Array<CursorSprite> = [];
+  private static var cursors: Map<String, CursorData> = new Map();
 
-  public static function createCursor(?bitmap: Bitmap) {
-    if (bitmap == null) {
-      bitmap = ImageManager.loadSystem(Main.params.cursorFilepath);
+  public static function removeCursor(data: CursorData) {
+    if (!cursors.exists(data.name)) {
+      cursors.remove(data.name);
     }
-    var sprite = new CursorSprite(bitmap);
-    sprite.anchor.set(0, 0);
-    return sprite;
   }
 
-  public static function loadCursor(?swap: Bool, onLoad: Dynamic->CursorSprite) {
-
+  public static function addCursor(data: CursorData) {
+    if (!cursors.exists(data.name)) {
+      cursors.set(data.name, data);
+    }
   }
 
-  public static function swapCursor(cursorId) {}
+  public static function changeCursor(name: String) {
+    if (cursors.exists(name)) {
+      var data = cursors.get(name);
+      getActiveCursor().cursorData = data;
+    }
+  }
 
-  public static function activeCursor(): CursorSprite {
+  public static function getActiveCursor(): CursorSprite {
     return untyped Amaryllis.currentScene()._cursor;
   }
 }

--- a/src/core/CursorLoader.hx
+++ b/src/core/CursorLoader.hx
@@ -8,7 +8,7 @@ class CursorLoader {
   private static var cursors: Map<String, CursorData> = new Map();
 
   public static function removeCursor(data: CursorData) {
-    if (!cursors.exists(data.name)) {
+    if (cursors.exists(data.name)) {
       cursors.remove(data.name);
     }
   }

--- a/src/core/CursorLoader.hx
+++ b/src/core/CursorLoader.hx
@@ -3,16 +3,12 @@ package core;
 import haxe.ds.Map;
 import sprites.CursorSprite;
 import types.CursorData;
+import rm.Globals.GameSystem;
 
 class CursorLoader {
   private static var cursors: Map<String, CursorData> = new Map();
 
-  public static var activeData(default, set): CursorData;
-
-  public static function set_activeData(data: CursorData) {
-    getActiveCursor().cursorData = data;
-    return activeData = data;
-  }
+  public static var activeData: CursorData;
 
   public static function hasActiveData(): Bool {
     return activeData != null;
@@ -34,6 +30,8 @@ class CursorLoader {
     if (cursors.exists(name)) {
       var data = cursors.get(name);
       activeData = data;
+      getActiveCursor().cursorData = activeData;
+      untyped GameSystem.activeCursor = activeData;
     }
   }
 

--- a/src/core/CursorLoader.hx
+++ b/src/core/CursorLoader.hx
@@ -1,0 +1,28 @@
+package core;
+
+import rm.core.Bitmap;
+import sprites.CursorSprite;
+import rm.managers.ImageManager;
+
+class CursorLoader {
+  private var _cache: Array<CursorSprite> = [];
+
+  public static function createCursor(?bitmap: Bitmap) {
+    if (bitmap == null) {
+      bitmap = ImageManager.loadSystem(Main.params.cursorFilepath);
+    }
+    var sprite = new CursorSprite(bitmap);
+    sprite.anchor.set(0, 0);
+    return sprite;
+  }
+
+  public static function loadCursor(?swap: Bool, onLoad: Dynamic->CursorSprite) {
+
+  }
+
+  public static function swapCursor(cursorId) {}
+
+  public static function activeCursor(): CursorSprite {
+    return untyped Amaryllis.currentScene()._cursor;
+  }
+}

--- a/src/core/CursorLoader.hx
+++ b/src/core/CursorLoader.hx
@@ -7,6 +7,17 @@ import types.CursorData;
 class CursorLoader {
   private static var cursors: Map<String, CursorData> = new Map();
 
+  public static var activeData(default, set): CursorData;
+
+  public static function set_activeData(data: CursorData) {
+    getActiveCursor().cursorData = data;
+    return activeData = data;
+  }
+
+  public static function hasActiveData(): Bool {
+    return activeData != null;
+  }
+
   public static function removeCursor(data: CursorData) {
     if (cursors.exists(data.name)) {
       cursors.remove(data.name);
@@ -22,7 +33,7 @@ class CursorLoader {
   public static function changeCursor(name: String) {
     if (cursors.exists(name)) {
       var data = cursors.get(name);
-      getActiveCursor().cursorData = data;
+      activeData = data;
     }
   }
 

--- a/src/core/Game_System.hx
+++ b/src/core/Game_System.hx
@@ -1,0 +1,10 @@
+package core;
+
+import rm.objects.Game_System as RmGame_System;
+
+class Game_System extends RmGame_System {
+  public override function initialize() {
+    untyped this.activeCursor = CursorLoader.activeData;
+    untyped _Game_System_initialize.call(this);
+  }
+}

--- a/src/core/LunaStage.hx
+++ b/src/core/LunaStage.hx
@@ -1,12 +1,15 @@
 package core;
 
+import sprites.CursorSprite;
 import rm.core.TouchInput;
 import core.Types.JsFn;
 import utils.Comment;
+import types.CursorData;
 import rm.core.Stage;
 import macros.FnMacros.self as sf;
 
 using utils.Fn;
+using Lambda;
 
 class LunaStage {
   public static inline function patch() {
@@ -27,8 +30,20 @@ class LunaStage {
 
     Stage.setPrPropFn('createMouseCursor', () -> {
       sf(Stage, {
+        var cursors: Array<Dynamic> = Main.params.cursors;
+        for (cursor in cursors) {
+          CursorLoader.addCursor({
+            name: cursor.filename,
+            url: 'img/system/${cursor.filename}.png',
+          });
+        }
         untyped {
-          self._cursor = CursorLoader.createCursor();
+          var defaultCursor = Main.params.cursors[0];
+          var bitmap = ImageManager.loadSystem(defaultCursor.filename);
+          self._cursor = new CursorSprite(bitmap, {
+            name: defaultCursor.filename,
+            url: bitmap.url
+          });
           self.addChild(self._cursor);
         }
       });

--- a/src/core/LunaStage.hx
+++ b/src/core/LunaStage.hx
@@ -1,10 +1,12 @@
 package core;
 
+import rm.managers.DataManager;
 import sprites.CursorSprite;
 import rm.core.TouchInput;
 import core.Types.JsFn;
 import utils.Comment;
 import rm.core.Stage;
+import rm.Globals.GameSystem;
 import macros.FnMacros.self as sf;
 
 using utils.Fn;
@@ -44,6 +46,9 @@ class LunaStage {
     Stage.setPrPropFn('updateCursors', () -> {
       sf(Stage, {
         var cursors: Array<Dynamic> = Main.params.cursors;
+        if (DataManager.isDatabaseLoaded() && CursorLoader.activeData == null && untyped GameSystem.activeCursor != null) {
+          CursorLoader.activeData = untyped GameSystem.activeCursor;
+        }
         if (CursorLoader.hasActiveData()) {
           untyped self.createMouseCursor(CursorLoader.activeData.name);
         } else {

--- a/src/core/LunaStage.hx
+++ b/src/core/LunaStage.hx
@@ -4,7 +4,6 @@ import sprites.CursorSprite;
 import rm.core.TouchInput;
 import core.Types.JsFn;
 import utils.Comment;
-import types.CursorData;
 import rm.core.Stage;
 import macros.FnMacros.self as sf;
 

--- a/src/core/LunaStage.hx
+++ b/src/core/LunaStage.hx
@@ -22,29 +22,39 @@ class LunaStage {
         untyped {
           self._cursorListener = self._mouseMoveListener.bind(self);
           TouchInput.addMouseMoveListener(self._cursorListener);
-          self.createMouseCursor();
+          self.updateCursors();
           document.body.style.cursor = 'none';
         }
       });
     }
 
-    Stage.setPrPropFn('createMouseCursor', () -> {
+    Stage.setPrPropFn('createMouseCursor', (filename: String) -> {
       sf(Stage, {
         var cursors: Array<Dynamic> = Main.params.cursors;
+        untyped {
+          var bitmap = ImageManager.loadSystem(filename);
+          self._cursor = new CursorSprite(bitmap, {
+            name: filename,
+            url: bitmap.url
+          });
+          self.addChild(self._cursor);
+        }
+      });
+    });
+
+    Stage.setPrPropFn('updateCursors', () -> {
+      sf(Stage, {
+        var cursors: Array<Dynamic> = Main.params.cursors;
+        if (CursorLoader.hasActiveData()) {
+          untyped self.createMouseCursor(CursorLoader.activeData.name);
+        } else {
+          untyped self.createMouseCursor(Main.params.cursors[0].filename);
+        }
         for (cursor in cursors) {
           CursorLoader.addCursor({
             name: cursor.filename,
             url: 'img/system/${cursor.filename}.png',
           });
-        }
-        untyped {
-          var defaultCursor = Main.params.cursors[0];
-          var bitmap = ImageManager.loadSystem(defaultCursor.filename);
-          self._cursor = new CursorSprite(bitmap, {
-            name: defaultCursor.filename,
-            url: bitmap.url
-          });
-          self.addChild(self._cursor);
         }
       });
     });

--- a/src/core/LunaStage.hx
+++ b/src/core/LunaStage.hx
@@ -3,9 +3,7 @@ package core;
 import rm.core.TouchInput;
 import core.Types.JsFn;
 import utils.Comment;
-import rm.core.Sprite;
 import rm.core.Stage;
-import rm.managers.ImageManager;
 import macros.FnMacros.self as sf;
 
 using utils.Fn;
@@ -30,11 +28,7 @@ class LunaStage {
     Stage.setPrPropFn('createMouseCursor', () -> {
       sf(Stage, {
         untyped {
-          var cursorBitmap = ImageManager.loadSystem(Main.params.cursorFilepath);
-          self._cursor = new Sprite(cursorBitmap);
-          self._cursor.anchor.set(0, 0);
-          self._cursor.x = 200;
-          self._cursor.y = 200;
+          self._cursor = CursorLoader.createCursor();
           self.addChild(self._cursor);
         }
       });

--- a/src/sprites/CursorSprite.hx
+++ b/src/sprites/CursorSprite.hx
@@ -1,0 +1,9 @@
+package sprites;
+
+import rm.core.Sprite;
+
+class CursorSprite extends Sprite {
+  public function new(bitmap) {
+    super(bitmap);
+  }
+}

--- a/src/sprites/CursorSprite.hx
+++ b/src/sprites/CursorSprite.hx
@@ -1,9 +1,31 @@
 package sprites;
 
 import rm.core.Sprite;
+import rm.managers.ImageManager;
+import types.CursorData;
 
 class CursorSprite extends Sprite {
-  public function new(bitmap) {
+  public var cursorData(default, set): CursorData;
+
+  public function new(bitmap, ?cursorData: CursorData) {
     super(bitmap);
+    if (cursorData != null) {
+      this.cursorData = cursorData;
+    }
+    this.cursorData = {
+      name: Utils.parseFilename(bitmap.url, false),
+      url: bitmap.url,
+    }
+  }
+
+  public function get_cursorData(): CursorData {
+    return this.cursorData;
+  }
+
+  public function set_cursorData(cursorData: CursorData) {
+    if (this.bitmap.url != cursorData.url) {
+      this.bitmap = ImageManager.loadSystem(cursorData.name);
+    }
+    return this.cursorData = cursorData;
   }
 }

--- a/src/types/CursorData.hx
+++ b/src/types/CursorData.hx
@@ -1,0 +1,6 @@
+package types;
+
+typedef CursorData = {
+  name: String,
+  url: String,
+}


### PR DESCRIPTION
- [x] Add skeleton class `CursorLoader` that handles all cursor data

- [x] Add plugin commands to change cursor data (and hide/show command)

- [x] Add bitmap swapping functionality to CursorSprite

- [x] Add basic parameters for adding multiple cursors

- [x] Ensure cursor stays persistent across scenes.

- [x] Save the current cursor to the savefile.